### PR TITLE
Update URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The project would be a first step in this direction and would include the follow
 
 ## Demo
 
-[Demo Link](https://tools.odpch.ch/siri-sx-map/setup)
+https://tools.opentransportdata.swiss/siri-sx/map/setup
 
 ## More Inforamtion
 

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -180,5 +180,5 @@ The parameters above are configurable via the `/setup` url.
 The URL can be then embedded in an HTML IFrame as in the following example:
 
 ```html
-<iframe width="100%" height="500" src="https://tools.odpch.ch/siri-sx-map/"></iframe>
+<iframe width="100%" height="500" src="https://tools.opentransportdata.swiss/siri-sx/map/"></iframe>
 ```


### PR DESCRIPTION
migrate to `tols.opentransportdata.swiss` domain